### PR TITLE
Fix schema type for properties with semantic type specified

### DIFF
--- a/src/clients/parseClient.ts
+++ b/src/clients/parseClient.ts
@@ -1,5 +1,5 @@
 import CommonInterface from "../models/commonInterface";
-import { CapabilityModel, InterfaceMap } from "../types/capabilities";
+import { CapabilityModel, InterfaceMap, Capability, CapabilityType } from "../types/capabilities";
 
 export function parse(capabilityModel: CapabilityModel, propertyCallback, commandCallback): InterfaceMap {
     let res = {};
@@ -12,13 +12,13 @@ export function parse(capabilityModel: CapabilityModel, propertyCallback, comman
                     if (interf.schema.contents && interf.schema.contents.length > 0) {
                         const items = interf.schema.contents;
                         items.forEach(item => {
-                            if (item["@type"] && item["@type"] === 'Property') {
+                            if (testForSchemaType(item, 'Property')) {
                                 cInf.addProperty(item.name,item.writable);
                             }
-                            else if (item["@type"] && item["@type"] === 'Command') {
+                            else if (testForSchemaType(item, 'Command')) {
                                 cInf.addCommand(item.name);
                             }
-                            else if (item["@type"] && item["@type"] === 'Telemetry') {
+                            else if (testForSchemaType(item, 'Telemetry')) {
                                 cInf.addTelemetry(item.name);
                             }
                         });
@@ -29,4 +29,10 @@ export function parse(capabilityModel: CapabilityModel, propertyCallback, comman
         });
     }
     return res;
+}
+
+function testForSchemaType(item: Capability, value: CapabilityType) {
+    const itemType = item["@type"];
+    return itemType &&
+           itemType instanceof Array ? itemType.includes(value) : itemType === value;
 }

--- a/src/clients/parseClient.ts
+++ b/src/clients/parseClient.ts
@@ -12,13 +12,13 @@ export function parse(capabilityModel: CapabilityModel, propertyCallback, comman
                     if (interf.schema.contents && interf.schema.contents.length > 0) {
                         const items = interf.schema.contents;
                         items.forEach(item => {
-                            if (testForSchemaType(item, 'Property')) {
+                            if (hasCapabilityType(item, 'Property')) {
                                 cInf.addProperty(item.name,item.writable);
                             }
-                            else if (testForSchemaType(item, 'Command')) {
+                            else if (hasCapabilityType(item, 'Command')) {
                                 cInf.addCommand(item.name);
                             }
-                            else if (testForSchemaType(item, 'Telemetry')) {
+                            else if (hasCapabilityType(item, 'Telemetry')) {
                                 cInf.addTelemetry(item.name);
                             }
                         });
@@ -31,7 +31,7 @@ export function parse(capabilityModel: CapabilityModel, propertyCallback, comman
     return res;
 }
 
-function testForSchemaType(item: Capability, value: CapabilityType) {
+function hasCapabilityType(item: Capability, value: CapabilityType) {
     const itemType = item["@type"];
     return itemType &&
            itemType instanceof Array ? itemType.includes(value) : itemType === value;

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -4,7 +4,7 @@ import { BaseInterface } from "azure-iot-digitaltwins-device"
 export type CapabilityType = 'InterfaceInstance' | 'Interface' | 'Property' | 'Command' | 'Telemetry'
 export type CapabilityId = {
     '@id': string,
-    '@type': CapabilityType,
+    '@type': CapabilityType | CapabilityType[],
     name?: string,
     displayName?: {
         [lang: string]: string


### PR DESCRIPTION
Properties/Telemetry that have a semantic type specified have a capability model with the type specified as an array instead. For example: 

`{
            "@id": "...CabinTemperature...",
            "@type": [
              "Telemetry",
              "SemanticType/Temperature"
            ],...
},`

Update capability type to allow for an array.

Note: I did not update CapabilityType constant since it was a lot of values and I wasn't sure how you might want to handle it i.e. include every Semantic type in this list as well or what.
`export type CapabilityType = 'InterfaceInstance' | 'Interface' | 'Property' | 'Command' | 'Telemetry'`